### PR TITLE
Update ploverdemo.js - fix color for final F

### DIFF
--- a/ploverpad/ploverdemo.js
+++ b/ploverpad/ploverdemo.js
@@ -176,11 +176,6 @@ function colorCode(keys) {
 		$('#stenoKey-L').css('background-color', '#80ffff');
 	}
 
-	// Final V
-	if ('-F' in stenoKeys) {
-		$('#stenoKey-F').css('background-color', '#808080');
-	}
-
 	// Final Z
 	if ('-Z' in stenoKeys) {
 		$('#stenoKey-Z').css('background-color', '#ff0000');


### PR DESCRIPTION
Currently, in the Plover demo, -F shows up as gray in the steno keyboard display, which matches with SR (initial V) rather than TP (initial F), which is green, due to -F also being final V and it overriding the color for F. This removes final V so that -F shows as green rather than gray.