### PR TITLE
add plover meetup event

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,10 @@ social:
   links:
     - https://www.facebook.com/openstenoproject/
 
+collections:
+  events:
+    sort-by: date
+
 # -----
 # Build
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,6 +11,10 @@
   link: /about/
   new_window: false
   highlight: false
+- name: Events
+  link: /events/
+  new_window: false
+  highlight: false
 - name: Donate
   link: /donate/
   new_window: false

--- a/_events/2022-01-19-Plover-Meetup.md
+++ b/_events/2022-01-19-Plover-Meetup.md
@@ -1,0 +1,12 @@
+---
+title: Plover Meetup
+date: 2022-01-19 16:00:00 EST
+location: <https://www.youtube.com/watch?v=F0nKjhlYofU>
+---
+
+This is a first-of-its-kind collaboration between the Open Steno community
+and a group of professional stenographic court reporters and realtime
+captioners, happening live over Zoom. The goal of this event is to raise
+awareness of Open Steno initiatives among the professional stenographer
+community, and create networking opportunities between them and amateur
+stenographers in the Open Steno community.

--- a/events.md
+++ b/events.md
@@ -1,0 +1,18 @@
+---
+
+title: Events
+description: Open Steno Events
+layout: post
+---
+
+{% for event in site.events reversed %}
+
+<h3>{{event.title}}</h3>
+
+<i class="fa-calendar-o fa fa-fw"></i> {{event.date | date: "%-d %B %Y, at %H:%M %Z" }}
+<br>
+<i class="fa-map-marker fa fa-fw"></i> {{event.location}}
+
+{{event.content}}
+
+{% endfor %}


### PR DESCRIPTION
Added an events collection. I've put the link in the navigation (but it's possible there's a better place, especially since the navigation is starting to become quite full), and it's possible to make new events by adding pages to the folder `_events`. I've put in the upcoming Plover meetup event with the wording from the discord event. Here's hoping there will be many more :)

Preview:
![image](https://user-images.githubusercontent.com/3298461/150210442-b92c2284-78b8-482e-b6c7-31c5b2ea4f7e.png)